### PR TITLE
make it work with newer VCD API that uses Bearer tokens

### DIFF
--- a/CIVMDisks.psd1
+++ b/CIVMDisks.psd1
@@ -12,7 +12,7 @@
 RootModule = 'CIVMDisks.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.4'
+ModuleVersion = '1.0.5'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
Newer versions of vCloud Director use [Bearer tokens](https://docs.vmware.com/en/VMware-Cloud-Director/10.3/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-A1B3B2FA-7B2C-4EE1-9D1B-188BE703EEDE.html) 
This change makes it possible to deal with that while retaining the old mechanism where needed.  

Also fixes an issue where comma's are returned for the API version for some localisation settings

Fixes jondwaite/CIVMDisks#5
Fixes jondwaite/CIVMDisks#4